### PR TITLE
Add ability to pass configuration for NProgress

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ That's it. Now NProgress will work automatically and will render the correct sty
 
 ### Advanced Config
 
-By passing an object as an optional second argument, you can configure further configure NProgress using it's [configuration options].
+By passing an object as an optional second argument, you can configure further configure NProgress using it's [configuration options](https://github.com/rstacruz/nprogress#configuration).
 
 ```js
 const msDelay = 200;

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ And render `NProgressStyles` inside your App container or [layout component](htt
 
 ```js
 // the default progress bar and spinner color is #29d, it could be changed for any CSS color
-<NProgressStyles color="#29d" />
+// Also, the default is to show the spinner, but that can be turned off.
+<NProgressStyles color="#29d" spinner={false} />
 ```
 
 That's it. Now NProgress will work automatically and will render the correct styles using styled-jsx.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ And render `NProgressStyles` inside your App container or [layout component](htt
 ```
 
 That's it. Now NProgress will work automatically and will render the correct styles using styled-jsx.
+
+### Advanced Config
+
+By passing an object as an optional second argument, you can configure further configure NProgress using it's [configuration options].
+
+```js
+const msDelay = 200;
+const configOptions = { trickleSpeed: 50 };
+export default withNProgress(msDelay, configOptions)(MyApp);
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ That's it. Now NProgress will work automatically and will render the correct sty
 
 ### Advanced Config
 
-By passing an object as an optional second argument, you can configure further configure NProgress using it's [configuration options](https://github.com/rstacruz/nprogress#configuration).
+You can configure further configure NProgress using its [configuration options](https://github.com/rstacruz/nprogress#configuration) by passing an object as an optional second argument.
 
 ```js
 const msDelay = 200;

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,10 @@ Router.onRouteChangeError = () => {
   clearTimeout(timer);
 };
 
-export default (_delayMs = delayMs) => {
+export default (_delayMs = delayMs, configOptions) => {
   delayMs = _delayMs;
-
+  // configure NProgress if configuration object is passed
+  if (configOptions) NProgress.configure(configOptions);
   // receive page and return it as is
   return Page => Page;
 };


### PR DESCRIPTION
This would let users pass a configuration argument which is then used for `NProgress.configure()`.

I also added a line in the readme explaining how people can turn the spinner on or off with the props in `<NProgressStyles />`. 

This takes care of issue #4  