### PR TITLE
Fix 'React is not defined'

### DIFF
--- a/src/hoc.js
+++ b/src/hoc.js
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import React, { Component } from "react";
 import NProgress from "./component";
 
 export default (delayMs, options) => Page =>


### PR DESCRIPTION
In prod, the `React` import must be within the file scope explicitly. Therefore, it is necessary to add `React` import on top of the file to avoid any potential error after build.