### PR TITLE
Use Next router events correctly (Fix #32)

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -11,6 +11,17 @@ class NProgressContainer extends React.Component {
 
   timer = null;
 
+  routeChangeStart = () => {
+    const { showAfterMs } = this.props;
+    clearTimeout(this.timer);
+    this.timer = setTimeout(NProgress.start, showAfterMs);
+  }
+
+  routeChangeEnd = () => {
+    clearTimeout(this.timer);
+    NProgress.done();
+  }
+
   componentDidMount() {
     const { options, router, showAfterMs } = this.props;
 
@@ -18,24 +29,16 @@ class NProgressContainer extends React.Component {
       NProgress.configure(options);
     }
 
-    router.events.on('routeChangeStart', () => {
-      clearTimeout(this.timer);
-      this.timer = setTimeout(NProgress.start, showAfterMs);
-    });
-
-    router.events.on('routeChangeComplete', () => {
-      clearTimeout(this.timer);
-      NProgress.done();
-    });
-
-    router.events.on('routeChangeError', () => {
-      clearTimeout(this.timer);
-      NProgress.done();
-    });
+    router.events.on('routeChangeStart', this.routeChangeStart);
+    router.events.on('routeChangeComplete', this.routeChangeEnd);
+    router.events.on('routeChangeError', this.routeChangeEnd);
   }
 
   componentWillUnmount() {
     clearTimeout(this.timer);
+    router.events.off('routeChangeStart', this.routeChangeStart);
+    router.events.off('routeChangeComplete', this.routeChangeEnd);
+    router.events.off('routeChangeError', this.routeChangeEnd);
   }
 
   render() {

--- a/src/component.js
+++ b/src/component.js
@@ -1,6 +1,6 @@
 import React from "react";
 import NProgress from "nprogress";
-import { withRouter } from "next/router";
+import Router from "next/router";
 
 class NProgressContainer extends React.Component {
   static defaultProps = {
@@ -23,22 +23,22 @@ class NProgressContainer extends React.Component {
   }
 
   componentDidMount() {
-    const { options, router } = this.props;
+    const { options } = this.props;
 
     if (options) {
       NProgress.configure(options);
     }
 
-    router.events.on('routeChangeStart', this.routeChangeStart);
-    router.events.on('routeChangeComplete', this.routeChangeEnd);
-    router.events.on('routeChangeError', this.routeChangeEnd);
+    Router.events.on('routeChangeStart', this.routeChangeStart);
+    Router.events.on('routeChangeComplete', this.routeChangeEnd);
+    Router.events.on('routeChangeError', this.routeChangeEnd);
   }
 
   componentWillUnmount() {
     clearTimeout(this.timer);
-    router.events.off('routeChangeStart', this.routeChangeStart);
-    router.events.off('routeChangeComplete', this.routeChangeEnd);
-    router.events.off('routeChangeError', this.routeChangeEnd);
+    Router.events.off('routeChangeStart', this.routeChangeStart);
+    Router.events.off('routeChangeComplete', this.routeChangeEnd);
+    Router.events.off('routeChangeError', this.routeChangeEnd);
   }
 
   render() {
@@ -129,4 +129,4 @@ class NProgressContainer extends React.Component {
   }
 }
 
-export default withRouter(NProgressContainer);
+export default NProgressContainer;

--- a/src/component.js
+++ b/src/component.js
@@ -23,7 +23,7 @@ class NProgressContainer extends React.Component {
   }
 
   componentDidMount() {
-    const { options, router, showAfterMs } = this.props;
+    const { options, router } = this.props;
 
     if (options) {
       NProgress.configure(options);

--- a/src/component.js
+++ b/src/component.js
@@ -18,32 +18,20 @@ class NProgressContainer extends React.Component {
       NProgress.configure(options);
     }
 
-    const previousChangeStartCallback = router.onRouteChangeStart;
-    const previousChangeCompleteCallback = router.onRouteChangeComplete;
-    const previousChangeErrorCallback = router.onRouteChangeError;
-    router.onRouteChangeStart = () => {
-      if (typeof previousChangeStartCallback === "function") {
-        previousChangeStartCallback();
-      }
+    router.events.on('routeChangeStart', () => {
       clearTimeout(this.timer);
       this.timer = setTimeout(NProgress.start, showAfterMs);
-    };
+    });
 
-    router.onRouteChangeComplete = () => {
-      if (typeof previousChangeCompleteCallback === "function") {
-        previousChangeCompleteCallback();
-      }
+    router.events.on('routeChangeComplete', () => {
       clearTimeout(this.timer);
       NProgress.done();
-    };
+    });
 
-    router.onRouteChangeError = () => {
-      if (typeof previousChangeErrorCallback === "function") {
-        previousChangeErrorCallback();
-      }
+    router.events.on('routeChangeError', () => {
       clearTimeout(this.timer);
       NProgress.done();
-    };
+    });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
We should bind to Next router events as documented [here](https://github.com/zeit/next.js/#router-events), rather than overriding callbacks.

Fixes #32 